### PR TITLE
Install separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installation
 
         cd OMERO_DIST/lib/scripts
 
-2. Clone the repository
+2. Clone the repository with a unique name (e.g. "useful_scripts")
 
         git clone https://github.com/THISREPOSITORY/omero-user-scripts.git UNIQUE_NAME
 
@@ -20,7 +20,7 @@ Installation
 Upgrading
 ---------
 
-1. Change into the repository location
+1. Change into the repository location cloned into during installation
 
         cd OMERO_DIST/lib/scripts/UNIQUE_NAME
 


### PR DESCRIPTION
The existing README is not particularly well suited to people who
actually want to _use_ a script repository rather than create their own
scripts via their own GitHub fork.  This commit improves that.

An HTTPS clone URL is also used for the user installation section.  This
URL is actually usable in a systems administration context where the
installation environment is not registered with GitHub.
